### PR TITLE
Improve direction choosing

### DIFF
--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -172,26 +172,33 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 - (void)mdc_executeOnPanBlockForTranslation:(CGPoint)translation {
     if (self.mdc_options.onPan) {
         CGFloat thresholdRatio = MIN(1.f, fabsf(translation.x)/self.mdc_options.threshold);
-
+        CGFloat upDownthresholdRatio = MIN(1.f, fabsf(translation.y / self.mdc_options.threshold));
+        thresholdRatio = MAX(thresholdRatio, upDownthresholdRatio);
+        
         MDCSwipeDirection direction = MDCSwipeDirectionNone;
-      
-        if (translation.x > 0.f) {
-          
-            direction = MDCSwipeDirectionRight;
-          
-        } else if (translation.x < 0.f) {
-          
-            direction = MDCSwipeDirectionLeft;
-          
-        } else if (translation.y > 0.f) {
-          
-            direction = MDCSwipeDirectionUp;
-          
-        } else if(translation.y < 0.f) {
-          
-            direction = MDCSwipeDirectionDown;
+        
+        if (fabsf(translation.x) > fabsf(translation.y)) {
+            if (translation.x > 0.f) {
+                
+                direction = MDCSwipeDirectionRight;
+                
+            } else if (translation.x < 0.f) {
+                
+                direction = MDCSwipeDirectionLeft;
+                
+            }
+        } else if (fabsf(translation.x) < fabsf(translation.y)) {
+            if (translation.y > 0.f) {
+                
+                direction = MDCSwipeDirectionUp;
+                
+            } else if(translation.y < 0.f) {
+                
+                direction = MDCSwipeDirectionDown;
+            }
         }
-
+        
+        
         MDCPanState *state = [MDCPanState new];
         state.view = self;
         state.direction = direction;


### PR DESCRIPTION
Changed the process for detecting the direction to be more accurate.
Added the 'translation.y' value for Up and Down directions.

As of now, it is not possible to detect the thresholdRatio value for Up and Down swipes. I added this functionality and changed the calculation on how directions are chosen to be more accurate with swipes which go a little bit into one direction but a little more into the other.
